### PR TITLE
Import k8s.io/api packages with consistent naming

### DIFF
--- a/e2e/infrastructure_agent_mutator_test.go
+++ b/e2e/infrastructure_agent_mutator_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -57,19 +57,19 @@ func Test_Infra_agent_injection_webhook(t *testing.T) {
 		testCommands = append(testCommands, fmt.Sprintf("kubectl get --raw %s", uri))
 	}
 
-	podTemplate := v1.Pod{
+	podTemplate := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: testPrefix,
 		},
-		Spec: v1.PodSpec{
-			InitContainers: []v1.Container{
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
 				{
 					Name:    "kubectl",
 					Image:   "bitnami/kubectl",
 					Command: []string{"sh", "-c", strings.Join(testCommands, "\n")},
 				},
 			},
-			Containers: []v1.Container{
+			Containers: []corev1.Container{
 				{
 					Name:  "nginx",
 					Image: "nginx",
@@ -209,7 +209,7 @@ func testClientset(t *testing.T) *kubernetes.Clientset {
 func withTestNamespace(ctx context.Context, t *testing.T, clientset *kubernetes.Clientset) string {
 	t.Helper()
 
-	namespaceTemplate := v1.Namespace{
+	namespaceTemplate := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: testPrefix,
 		},

--- a/internal/mutator/pod/agent/secret.go
+++ b/internal/mutator/pod/agent/secret.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -24,7 +24,7 @@ const (
 // ensureLicenseSecretExistence assures that the license secret exists and it is well configured, otherwise patches the
 // existing object or create a new one.
 func (i *injector) ensureLicenseSecretExistence(ctx context.Context, namespace string) error {
-	s := &v1.Secret{}
+	s := &corev1.Secret{}
 	key := client.ObjectKey{
 		Namespace: namespace,
 		Name:      i.licenseSecretName,
@@ -48,7 +48,7 @@ func (i *injector) ensureLicenseSecretExistence(ctx context.Context, namespace s
 }
 
 func (i *injector) createSecret(ctx context.Context, namespace string) error {
-	s := &v1.Secret{
+	s := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      i.licenseSecretName,
 			Namespace: namespace,
@@ -59,7 +59,7 @@ func (i *injector) createSecret(ctx context.Context, namespace string) error {
 		Data: map[string][]byte{
 			LicenseSecretKey: i.license,
 		},
-		Type: v1.SecretTypeOpaque,
+		Type: corev1.SecretTypeOpaque,
 	}
 
 	if err := i.noCacheClient.Create(ctx, s, &client.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
@@ -69,7 +69,7 @@ func (i *injector) createSecret(ctx context.Context, namespace string) error {
 	return nil
 }
 
-func (i *injector) updateSecret(ctx context.Context, s *v1.Secret) error {
+func (i *injector) updateSecret(ctx context.Context, s *corev1.Secret) error {
 	// When we update we should not add the label since likely the user or a different newrelic installation created
 	// such secret.
 	s.Data[LicenseSecretKey] = i.license

--- a/internal/operator/operator_integration_test.go
+++ b/internal/operator/operator_integration_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	admissionv1 "k8s.io/api/admission/v1"
-	v1 "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
@@ -432,11 +432,11 @@ func createClusterRoleBinding(ctx context.Context, t *testing.T, options operato
 		t.Fatalf("initializing client: %v", err)
 	}
 
-	crb := v1.ClusterRoleBinding{
+	crb := rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("%s%s", testPrefix, agent.ClusterRoleBindingSuffix),
 		},
-		RoleRef: v1.RoleRef{
+		RoleRef: rbacv1.RoleRef{
 			// Note that we are not interested into having the real role bound.
 			Name: "view",
 			Kind: "ClusterRole",


### PR DESCRIPTION
So it is not context-dependent if v1 is corev1 or rbacv1.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>