### PR TITLE
 internal/operator: add IgnoreMutationErrors option + some small improvements

### DIFF
--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -35,6 +35,7 @@ type Options struct {
 	Port                   int
 	RestConfig             *rest.Config
 	Logger                 *logrus.Logger
+	IgnoreMutationErrors   bool
 
 	InfraAgentInjection agent.InjectorConfig
 }
@@ -81,6 +82,8 @@ func Run(ctx context.Context, options Options) error {
 
 	admission := &webhook.Admission{
 		Handler: &podMutatorHandler{
+			ignoreMutationErrors: options.IgnoreMutationErrors,
+			logger:               options.Logger,
 			mutators: []podMutator{
 				agentInjector,
 			},

--- a/internal/operator/pod_mutator_handler.go
+++ b/internal/operator/pod_mutator_handler.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -19,8 +20,10 @@ type podMutator interface {
 }
 
 type podMutatorHandler struct {
-	decoder  *admission.Decoder
-	mutators []podMutator
+	decoder              *admission.Decoder
+	mutators             []podMutator
+	ignoreMutationErrors bool
+	logger               *logrus.Logger
 }
 
 // Handle is in charge of handling the request received involving new pods.
@@ -41,6 +44,12 @@ func (a *podMutatorHandler) Handle(ctx context.Context, req admission.Request) a
 
 	for _, m := range a.mutators {
 		if err := m.Mutate(ctx, pod, requestOptions); err != nil {
+			if a.ignoreMutationErrors {
+				a.logger.Warnf("Pod %s/%s mutation failed: %v", pod.Name, req.Namespace, err)
+
+				return admission.PatchResponseFromRaw(req.Object.Raw, req.Object.Raw)
+			}
+
 			return admission.Errored(http.StatusInternalServerError, err)
 		}
 	}


### PR DESCRIPTION
If mutation fails for any reason, user can configure
ignoreMutationErrors configuration option, which will only make errors
being logged and empty patch will be returned to the Kubernetes API,
which should increase the reliability of creating Pods in case of
operator misbehaving.

By default this behavior is disabled.

Closes #7

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>