### PR TITLE
[CI/CD] fix e2e tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,18 +87,8 @@ jobs:
           restore-keys: |
             gobuild-linux-amd64
 
-      - name: Checkout charts repository for deployments
-        uses: actions/checkout@v2
-        with:
-          repository: newrelic/helm-charts
-          ref: invidian/nri-kubernetes-operator
-          path: helm-charts-newrelic
-
-      - name: Install Helm
-        uses: azure/setup-helm@v1
-
-      - name: Install kind
-        run: go install sigs.k8s.io/kind@v0.10.0
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.2.0
 
       - name: Create k8s Kind Cluster
         run: make -C newrelic-infra-operator kind-up
@@ -113,7 +103,11 @@ jobs:
         env:
           KUBECONFIG: ./newrelic-infra-operator/kubeconfig
         run: |
-          helm install newrelic-infra-operator ./helm-charts-newrelic/charts/newrelic-infra-operator --values ./newrelic-infra-operator/values-dev.yaml --set image.repository=localhost:5000/newrelic-infra-operator
+          helm repo add newrelic https://helm-charts.newrelic.com
+          helm repo update
+          helm install newrelic-infra-operator newrelic/newrelic-infra-operator \
+          --values ./newrelic-infra-operator/values-dev.yaml \
+          --set image.repository=localhost:5000/newrelic-infra-operator
 
       - name: Run e2e tests
         run: make -C newrelic-infra-operator test-e2e

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,8 +87,14 @@ jobs:
           restore-keys: |
             gobuild-linux-amd64
 
-      - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
+      - name: Checkout charts repository for deployments
+        uses: actions/checkout@v2
+        with:
+          repository: newrelic/helm-charts
+          path: helm-charts-newrelic
+
+      - name: Install kind
+        run: go install sigs.k8s.io/kind@v0.11.1
 
       - name: Create k8s Kind Cluster
         run: make -C newrelic-infra-operator kind-up
@@ -103,9 +109,7 @@ jobs:
         env:
           KUBECONFIG: ./newrelic-infra-operator/kubeconfig
         run: |
-          helm repo add newrelic https://helm-charts.newrelic.com
-          helm repo update
-          helm install newrelic-infra-operator newrelic/newrelic-infra-operator \
+          helm install newrelic-infra-operator ./helm-charts-newrelic/charts/newrelic-infra-operator \
           --values ./newrelic-infra-operator/values-dev.yaml \
           --set image.repository=localhost:5000/newrelic-infra-operator
 


### PR DESCRIPTION
I am not 100% sure of the root cause, however in that specific kind version the dns pods were having issues:

```
$ Run kubectl get pods --all-namespaces
kube-system          kube-proxy-zs5ks                                 0/1     CrashLoopBackOff   5          3m53s
local-path-storage   local-path-provisioner-78776bfc44-jkwmh          0/1     Pending            0          3m53s
default              newrelic-infra-operator-admission-create-s8b7s   0/1     Pending            0          2m
kube-system          coredns-f9fd979d6-428m6                          0/1     Pending            0          3m53s
kube-system          coredns-f9fd979d6-khcjb                          0/1     Pending            0          3m52s
```

It is possible that github updated the kernel version of the runners breaking the behaviour:
Possibly related issue https://github.com/kubernetes-sigs/kind/issues/2240