### PR TITLE
Fix goheader lint

### DIFF
--- a/e2e/infrastructure_agent_mutator_test.go
+++ b/e2e/infrastructure_agent_mutator_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 New Relic Corporation. All rights reserved.
+// Copyright 2022 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build e2e

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,4 +1,4 @@
-// Copyright 2021 New Relic Corporation. All rights reserved.
+// Copyright 2022 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package cli provides CLI implementation for operator.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 New Relic Corporation. All rights reserved.
+// Copyright 2022 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package cli_test

--- a/internal/mutator/pod/agent/agent_config.go
+++ b/internal/mutator/pod/agent/agent_config.go
@@ -1,4 +1,4 @@
-// Copyright 2021 New Relic Corporation. All rights reserved.
+// Copyright 2022 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package agent

--- a/internal/mutator/pod/agent/cluster_role_binding.go
+++ b/internal/mutator/pod/agent/cluster_role_binding.go
@@ -1,4 +1,4 @@
-// Copyright 2021 New Relic Corporation. All rights reserved.
+// Copyright 2022 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package agent

--- a/internal/mutator/pod/agent/injector.go
+++ b/internal/mutator/pod/agent/injector.go
@@ -1,4 +1,4 @@
-// Copyright 2021 New Relic Corporation. All rights reserved.
+// Copyright 2022 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package agent implements injection of infrastructure-agent container into given Pod.

--- a/internal/mutator/pod/agent/injector_test.go
+++ b/internal/mutator/pod/agent/injector_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 New Relic Corporation. All rights reserved.
+// Copyright 2022 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package agent_test

--- a/internal/mutator/pod/agent/secret.go
+++ b/internal/mutator/pod/agent/secret.go
@@ -1,4 +1,4 @@
-// Copyright 2021 New Relic Corporation. All rights reserved.
+// Copyright 2022 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package agent

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -1,4 +1,4 @@
-// Copyright 2021 New Relic Corporation. All rights reserved.
+// Copyright 2022 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package operator exports top-level operator logic for users like CLI package to consume.

--- a/internal/operator/operator_integration_test.go
+++ b/internal/operator/operator_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 New Relic Corporation. All rights reserved.
+// Copyright 2022 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration

--- a/internal/operator/pod_mutator_handler.go
+++ b/internal/operator/pod_mutator_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2021 New Relic Corporation. All rights reserved.
+// Copyright 2022 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package operator

--- a/internal/operator/pod_mutator_handler_internal_test.go
+++ b/internal/operator/pod_mutator_handler_internal_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 New Relic Corporation. All rights reserved.
+// Copyright 2022 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package operator

--- a/internal/testutil/util.go
+++ b/internal/testutil/util.go
@@ -1,4 +1,4 @@
-// Copyright 2021 New Relic Corporation. All rights reserved.
+// Copyright 2022 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package testutil provides common helper for tests.

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -1,4 +1,4 @@
-// Copyright 2021 New Relic Corporation. All rights reserved.
+// Copyright 2022 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package webhook provides the configuration for the different webhooks

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright 2021 New Relic Corporation. All rights reserved.
+// Copyright 2022 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,4 +1,4 @@
-// Copyright 2021 New Relic Corporation. All rights reserved.
+// Copyright 2022 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // +build tools


### PR DESCRIPTION
golangci-lint is complaining that our heders are outdated:
![Screenshot 2022-05-10 at 14 28 06](https://user-images.githubusercontent.com/53659978/167628203-2f657e74-fdc2-4a6b-95e7-d82ad93e2ea7.png)

This PR should fix it.