### PR TITLE
[chart] Template `imagePullSecrets` also they come from `global`

### DIFF
--- a/charts/newrelic-infra-operator/Chart.yaml
+++ b/charts/newrelic-infra-operator/Chart.yaml
@@ -7,7 +7,7 @@ sources:
   - https://github.com/newrelic/newrelic-infra-operator
   - https://github.com/newrelic/newrelic-infra-operator/tree/master/charts/newrelic-infra-operator
 
-version: 1.0.2
+version: 1.0.3
 appVersion: 0.6.0
 
 dependencies:

--- a/charts/newrelic-infra-operator/README.md
+++ b/charts/newrelic-infra-operator/README.md
@@ -1,6 +1,6 @@
 # newrelic-infra-operator
 
-![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
+![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
 
 A Helm chart to deploy the New Relic Infrastructure Kubernetes Operator.
 

--- a/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -18,9 +18,9 @@ spec:
         app: {{ include "newrelic-infra-operator.name.admission-create" . }}
         {{- include "newrelic.common.labels.podLabels" . | nindent 8 }}
     spec:
-      {{- if .Values.admissionWebhooksPatchJob.image.pullSecrets }}
+      {{- with include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" ( list .Values.admissionWebhooksPatchJob.image.pullSecrets ) "context" .) }}
       imagePullSecrets:
-        {{- include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" ( list .Values.admissionWebhooksPatchJob.image.pullSecrets ) "context" .) | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       containers:
         - name: create

--- a/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -18,9 +18,9 @@ spec:
         app: {{ include "newrelic-infra-operator.name.admission-patch" . }}
         {{- include "newrelic.common.labels" . | nindent 8 }}
     spec:
-      {{- if .Values.admissionWebhooksPatchJob.image.pullSecrets }}
+      {{- with include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" ( list .Values.admissionWebhooksPatchJob.image.pullSecrets ) "context" .) }}
       imagePullSecrets:
-        {{- include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" ( list .Values.admissionWebhooksPatchJob.image.pullSecrets ) "context" .) | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       containers:
         - name: patch

--- a/charts/newrelic-infra-operator/templates/deployment.yaml
+++ b/charts/newrelic-infra-operator/templates/deployment.yaml
@@ -26,9 +26,9 @@ spec:
       securityContext:
         {{- . | nindent 8 }}
       {{- end }}
-      {{- if .Values.image.pullSecrets }}
+      {{- with include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" ( list .Values.image.pullSecrets ) "context" .) }}
       imagePullSecrets:
-        {{- include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" ( list .Values.image.pullSecrets ) "context" .) | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       containers:
       - name: {{ include "newrelic.common.naming.name" . }}


### PR DESCRIPTION
This chart was ignoring global.images.pullSecrets because it was testing only the local ones.

This should fix the issue.
