### PR TITLE
[helm chart] Patch job should also honor the global service account flag

### DIFF
--- a/charts/newrelic-infra-operator/Chart.yaml
+++ b/charts/newrelic-infra-operator/Chart.yaml
@@ -7,7 +7,7 @@ sources:
   - https://github.com/newrelic/newrelic-infra-operator
   - https://github.com/newrelic/newrelic-infra-operator/tree/master/charts/newrelic-infra-operator
 
-version: 1.0.4
+version: 1.0.5
 appVersion: 0.6.0
 
 dependencies:

--- a/charts/newrelic-infra-operator/templates/_helpers.tpl
+++ b/charts/newrelic-infra-operator/templates/_helpers.tpl
@@ -24,6 +24,14 @@ Naming helpers
 {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "admission") }}
 {{- end -}}
 
+{{- define "newrelic-infra-operator.fullname.admission.serviceAccount" -}}
+{{- if include "newrelic.common.serviceAccount.create" . -}}
+  {{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "admission") -}}
+{{- else -}}
+  {{- include "newrelic.common.serviceAccount.name" . -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "newrelic-infra-operator.name.admission-create" -}}
 {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.name" .) "suffix" "admission-create") }}
 {{- end -}}

--- a/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
+++ b/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
@@ -15,6 +15,6 @@ roleRef:
   name: {{ include "newrelic-infra-operator.fullname.admission" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "newrelic-infra-operator.fullname.admission" . }}
+    name: {{ include "newrelic-infra-operator.fullname.admission.serviceAccount" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -42,7 +42,7 @@ spec:
       {{- include "tplvalues.render" ( dict "value" .Values.admissionWebhooksPatchJob.image.volumes "context" $ ) | nindent 8 }}
       {{- end }}
       restartPolicy: OnFailure
-      serviceAccountName: {{ include "newrelic-infra-operator.fullname.admission" . }}
+      serviceAccountName: {{ include "newrelic-infra-operator.fullname.admission.serviceAccount" . }}
       securityContext:
         runAsGroup: 2000
         runAsNonRoot: true

--- a/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -42,7 +42,7 @@ spec:
       {{- include "tplvalues.render" ( dict "value" .Values.admissionWebhooksPatchJob.image.volumes "context" $ ) | nindent 8 }}
       {{- end }}
       restartPolicy: OnFailure
-      serviceAccountName: {{ include "newrelic-infra-operator.fullname.admission" . }}
+      serviceAccountName: {{ include "newrelic-infra-operator.fullname.admission.serviceAccount" . }}
       securityContext:
         runAsGroup: 2000
         runAsNonRoot: true

--- a/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/rolebinding.yaml
+++ b/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/rolebinding.yaml
@@ -16,6 +16,6 @@ roleRef:
   name: {{ include "newrelic-infra-operator.fullname.admission" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "newrelic-infra-operator.fullname.admission" . }}
+    name: {{ include "newrelic-infra-operator.fullname.admission.serviceAccount" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/serviceaccount.yaml
+++ b/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/serviceaccount.yaml
@@ -1,9 +1,10 @@
-{{- if (and (not .Values.customTLSCertificate) (not .Values.certManager.enabled)) }}
+{{- $createServiceAccount := include "newrelic.common.serviceAccount.create" . -}}
+{{- if (and $createServiceAccount (not .Values.customTLSCertificate) (not .Values.certManager.enabled)) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ include "newrelic-infra-operator.fullname.admission" . }}
+  name: {{ include "newrelic-infra-operator.fullname.admission.serviceAccount" . }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/charts/newrelic-infra-operator/tests/job_serviceaccount_test.yaml
+++ b/charts/newrelic-infra-operator/tests/job_serviceaccount_test.yaml
@@ -1,0 +1,35 @@
+suite: test job' serviceAccount
+templates:
+  - templates/admission-webhooks/job-patch/job-createSecret.yaml
+  - templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+tests:
+  - it: RBAC points to the service account that is created by default
+    set:
+      rbac.create: true
+      serviceAccount.create: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: my-release-newrelic-infra-operator-admission
+
+  - it: RBAC points to the service account the user supplies when serviceAccount is disabled
+    set:
+      rbac.create: true
+      serviceAccount.create: false
+      serviceAccount.name: sa-test
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: sa-test
+
+  - it: RBAC points to the service account the user supplies when serviceAccount is disabled
+    set:
+      rbac.create: true
+      serviceAccount.create: false
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: default

--- a/charts/newrelic-infra-operator/tests/rbac_test.yaml
+++ b/charts/newrelic-infra-operator/tests/rbac_test.yaml
@@ -1,0 +1,35 @@
+suite: test RBAC creation
+templates:
+  - templates/admission-webhooks/job-patch/rolebinding.yaml
+  - templates/admission-webhooks/job-patch/clusterrolebinding.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+tests:
+  - it: RBAC points to the service account that is created by default
+    set:
+      rbac.create: true
+      serviceAccount.create: true
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: my-release-newrelic-infra-operator-admission
+
+  - it: RBAC points to the service account the user supplies when serviceAccount is disabled
+    set:
+      rbac.create: true
+      serviceAccount.create: false
+      serviceAccount.name: sa-test
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: sa-test
+
+  - it: RBAC points to the service account the user supplies when serviceAccount is disabled
+    set:
+      rbac.create: true
+      serviceAccount.create: false
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: default


### PR DESCRIPTION
There is an issue open by GTS saying that not all the charts honor the flag `.global.serviceAccount.create` and `.global.serviceAccount.name`: newrelic/helm-charts#875

There is not also the issue that they are not honored by the deployments but also by the jobs that create and patch webhook certificates.
