### PR TITLE
[chart] Fix `podLabels`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,13 +44,13 @@ jobs:
             fi
           done
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.4.3
+        uses: manusa/actions-setup-minikube@v2.7.0
         if: steps.list-changed.outputs.changed == 'true'
         with:
           minikube version: v1.20.0
           kubernetes version: ${{ matrix.kubernetes-version }}
           github token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         if: steps.list-changed.outputs.changed == 'true'
         with:
           go-version: '1.18'
@@ -82,7 +82,7 @@ jobs:
       GOARCH: ${{ matrix.goarch }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: '1.18'
 
@@ -122,7 +122,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: '1.18'
         id: go

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
         goarch: [ amd64, arm64, arm ]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: '1.18'
 

--- a/charts/newrelic-infra-operator/Chart.lock
+++ b/charts/newrelic-infra-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: https://helm-charts.newrelic.com
-  version: 1.0.6
-digest: sha256:6297ce49be6028ef42ecdbe102046c96dbda7d8e42f759ba77f140592fb5dd3a
-generated: "2022-08-30T09:44:01.511352+02:00"
+  version: 1.1.0
+digest: sha256:2784850d2fcf8acf99ea543b6ef0b7db24ba0b88f9c0aa83edbada0bebdc4fa8
+generated: "2022-09-07T12:01:15.642341434Z"

--- a/charts/newrelic-infra-operator/Chart.yaml
+++ b/charts/newrelic-infra-operator/Chart.yaml
@@ -7,7 +7,7 @@ sources:
   - https://github.com/newrelic/newrelic-infra-operator
   - https://github.com/newrelic/newrelic-infra-operator/tree/main/charts/newrelic-infra-operator
 
-version: 1.0.7
+version: 1.0.8
 appVersion: 0.6.0
 
 dependencies:

--- a/charts/newrelic-infra-operator/Chart.yaml
+++ b/charts/newrelic-infra-operator/Chart.yaml
@@ -12,7 +12,7 @@ appVersion: 0.6.0
 
 dependencies:
   - name: common-library
-    version: 1.0.6
+    version: 1.1.0
     repository: "https://helm-charts.newrelic.com"
 
 maintainers:

--- a/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -24,7 +24,7 @@ spec:
       {{- end }}
       containers:
         - name: create
-          image: {{ include "newrelic.common.images.image" ( dict "imageRoot" .Values.admissionWebhooksPatchJob.image "context" .) }}
+          image: {{ include "newrelic.common.images.image" ( dict "defaultRegistry" "k8s.gcr.io" "imageRoot" .Values.admissionWebhooksPatchJob.image "context" .) }}
           imagePullPolicy: {{ .Values.admissionWebhooksPatchJob.image.pullPolicy }}
           args:
             - create

--- a/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -24,7 +24,7 @@ spec:
       {{- end }}
       containers:
         - name: patch
-          image: {{ include "newrelic.common.images.image" ( dict "imageRoot" .Values.admissionWebhooksPatchJob.image "context" .) }}
+          image: {{ include "newrelic.common.images.image" ( dict "defaultRegistry" "k8s.gcr.io" "imageRoot" .Values.admissionWebhooksPatchJob.image "context" .) }}
           imagePullPolicy: {{ .Values.admissionWebhooksPatchJob.image.pullPolicy }}
           args:
             - patch

--- a/charts/newrelic-infra-operator/templates/deployment.yaml
+++ b/charts/newrelic-infra-operator/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "newrelic.common.labels" . | nindent 8 }}
+        {{- include "newrelic.common.labels.podLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "newrelic.common.serviceAccount.name" . }}
       {{- with include "newrelic.common.securityContext.pod" . }}

--- a/charts/newrelic-infra-operator/values.yaml
+++ b/charts/newrelic-infra-operator/values.yaml
@@ -26,9 +26,9 @@ image:
 # @default -- See `values.yaml`
 admissionWebhooksPatchJob:
   image:
-    registry: k8s.gcr.io
+    registry:  # Defaults to k8s.gcr.io
     repository: ingress-nginx/kube-webhook-certgen
-    tag: v1.1.1
+    tag: v1.3.0
     pullPolicy: IfNotPresent
     # -- The secrets that are needed to pull images from a custom registry.
     pullSecrets: []


### PR DESCRIPTION
We were using `labels` instead of `podLabels` in the pods so we were not leveraging the `common-library` properly.

Fixes newrelic/nri-kube-events#142