### PR TITLE
Poc Implementing v3

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -7,7 +7,7 @@ project_name = 'newrelic-infra-operator'
 settings = {
   'kind_cluster_name': 'kind',
   'live_reload': True,
-  'chart_path': '../helm-charts-newrelic/charts/%s/' % project_name,
+  'chart_path': './charts/%s/' % project_name,
 }
 
 settings.update(read_json('tilt_option.json', default={}))

--- a/charts/newrelic-infra-operator/templates/_helpers.tpl
+++ b/charts/newrelic-infra-operator/templates/_helpers.tpl
@@ -79,6 +79,10 @@ Returns Infra-agent rules
 - apiGroups: [""]
   resources:
     - "nodes"
+  verbs: ["watch"]
+- apiGroups: [""]
+  resources:
+    - "nodes"
     - "nodes/metrics"
     - "nodes/stats"
     - "nodes/proxy"

--- a/charts/newrelic-infra-operator/templates/clusterrole.yaml
+++ b/charts/newrelic-infra-operator/templates/clusterrole.yaml
@@ -14,7 +14,13 @@ rules:
   {{/* resourceNames used above do not support "create" verb. */ -}}
   - apiGroups: [""]
     resources:
+      - "configmaps"
+    verbs: ["get", "update", "patch"]
+    resourceNames: [ "newrelic-kubelet-scraper-config" ]
+  - apiGroups: [""]
+    resources:
       - "secrets"
+      - "configmaps"
     verbs: ["create"]
   {{/* "list" and "watch" are required for controller-runtime caching. */ -}}
   - apiGroups: ["rbac.authorization.k8s.io"]

--- a/charts/newrelic-infra-operator/values.yaml
+++ b/charts/newrelic-infra-operator/values.yaml
@@ -135,8 +135,8 @@ config:
       # -- Image of the infrastructure agent to be injected.
       # @default -- See `values.yaml`
       image:
-        repository: newrelic/infrastructure-k8s
-        tag: 2.13.2-unprivileged
+        repository: newrelic/infrastructure-bundle
+        tag: 2.8.28
         pullPolicy: IfNotPresent
 
       # -- configSelectors is the way to configure resource requirements and extra envVars of the injected sidecar container.
@@ -151,58 +151,42 @@ config:
             memory: 50M
             cpu: 100m
         extraEnvVars:  # extraEnvVars to pass to the injected sidecar.
-          DISABLE_KUBE_STATE_METRICS: "true"
         # NRIA_VERBOSE: "1"
-        labelSelector:
-          matchExpressions:
-          - key: "app.kubernetes.io/name"
-            operator: NotIn
-            values: ["kube-state-metrics"]
-          - key: "app"
-            operator: NotIn
-            values: ["kube-state-metrics"]
-          - key: "k8s-app"
-            operator: NotIn
-            values: ["kube-state-metrics"]
 
-      - resourceRequirements:
-          limits:
-            memory: 300M
-            cpu: 300m
-          requests:
-            memory: 150M
-            cpu: 150m
-        labelSelector:
-          matchLabels:
-            k8s-app: kube-state-metrics
-      # extraEnvVars:
-      #   NRIA_VERBOSE: "1"
+    # -- kubeletConfig contains the configuration for the container agent injected
+    # @default -- See `values.yaml`
+    kubeletConfig:
 
-      - resourceRequirements:
-          limits:
-            memory: 300M
-            cpu: 300m
-          requests:
-            memory: 150M
-            cpu: 150m
-        labelSelector:
-          matchLabels:
-            app: kube-state-metrics
-      # extraEnvVars:
-      #   NRIA_VERBOSE: "1"
+      # -- Image of the infrastructure agent to be injected.
+      # @default -- See `values.yaml`
+      image:
+        repository: newrelic/nri-kubernetes
+        tag: 3.4.2
+        pullPolicy: IfNotPresent
 
-      - resourceRequirements:
-          limits:
-            memory: 300M
-            cpu: 300m
-          requests:
-            memory: 150M
-            cpu: 150m
-        labelSelector:
-          matchLabels:
-            app.kubernetes.io/name: kube-state-metrics
-      # extraEnvVars:
-      #   NRIA_VERBOSE: "1"
+      scraperConfigToInject: |-
+        verbose: true
+        interval: 10s
+        kubelet:
+          # -- Timeout for the kubelet APIs contacted by the integration
+          timeout: 10s
+          # -- Number of retries after timeout expired
+          retries: 3
+          enabled: true
+
+      # -- configSelectors is the way to configure resource requirements and extra envVars of the injected sidecar container.
+      # When mutating it will be applied the first configuration having the labelSelector matching with the mutating pod.
+      # @default -- See `values.yaml`
+      configSelectors:
+        - resourceRequirements:  # resourceRequirements to apply to the injected sidecar.
+            limits:
+              memory: 100M
+              cpu: 200m
+            requests:
+              memory: 50M
+              cpu: 100m
+          extraEnvVars:  # extraEnvVars to pass to the injected sidecar.
+          # NRI_KUBERNETES_VERBOSE: "true"
 
       # pod Security Context of the sidecar injected.
       # Notice that ReadOnlyRootFilesystem and AllowPrivilegeEscalation enforced respectively to true and to false.

--- a/hack/kind-with-registry.sh
+++ b/hack/kind-with-registry.sh
@@ -3,27 +3,32 @@ set -o errexit
 
 # create registry container unless it already exists
 reg_name='kind-registry'
-reg_port='5000'
-running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
-if [ "${running}" != 'true' ]; then
+reg_port='5001'
+if [ "$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)" != 'true' ]; then
   docker run \
     -d --restart=always -p "127.0.0.1:${reg_port}:5000" --name "${reg_name}" \
     registry:2
 fi
 
 # create a cluster with the local registry enabled in containerd
-cat <<EOF | kind create cluster --image=kindest/node:v1.19.7 --config=-
+cat <<EOF | kind create cluster --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  image: kindest/node:v1.24.4@sha256:adfaebada924a26c2c9308edd53c6e33b3d4e453782c0063dc0028bdebaddf98
+- role: worker
+  image: kindest/node:v1.24.4@sha256:adfaebada924a26c2c9308edd53c6e33b3d4e453782c0063dc0028bdebaddf98
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
-    endpoint = ["http://${reg_name}:${reg_port}"]
+    endpoint = ["http://${reg_name}:5000"]
 EOF
 
-# connect the registry to the cluster network
-# (the network may already be connected)
-docker network connect "kind" "${reg_name}" || true
+# connect the registry to the cluster network if not already connected
+if [ "$(docker inspect -f='{{json .NetworkSettings.Networks.kind}}' "${reg_name}")" = 'null' ]; then
+  docker network connect "kind" "${reg_name}"
+fi
 
 # Document the local registry
 # https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -41,10 +41,10 @@ func Options(path string) (*operator.Options, error) {
 		return nil, fmt.Errorf("parsing configuration file content: %w", err)
 	}
 
-	options.InfraAgentInjection.License = os.Getenv(EnvLicenseKey)
+	options.KubernetesIntegrationInjection.License = os.Getenv(EnvLicenseKey)
 
-	if options.InfraAgentInjection.ClusterName == "" {
-		options.InfraAgentInjection.ClusterName = os.Getenv(EnvClusterName)
+	if options.KubernetesIntegrationInjection.ClusterName == "" {
+		options.KubernetesIntegrationInjection.ClusterName = os.Getenv(EnvClusterName)
 	}
 
 	return options, nil

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -41,15 +41,15 @@ func Test_Options(t *testing.T) {
 			expectedName := "computeType"
 			expectedDefaultValue := "serverless"
 
-			if options.InfraAgentInjection.AgentConfig.CustomAttributes == nil {
+			if options.KubernetesIntegrationInjection.AgentConfig.CustomAttributes == nil {
 				t.Fatalf("expected agent config to not be empty")
 			}
 
-			if l := len(options.InfraAgentInjection.AgentConfig.CustomAttributes); l != 1 {
+			if l := len(options.KubernetesIntegrationInjection.AgentConfig.CustomAttributes); l != 1 {
 				t.Fatalf("didn't find 1 customAttributes %d", l)
 			}
 
-			ca := options.InfraAgentInjection.AgentConfig.CustomAttributes[0]
+			ca := options.KubernetesIntegrationInjection.AgentConfig.CustomAttributes[0]
 			if ca.Name != expectedName {
 				t.Fatalf("expected name %q, got %q", expectedName, ca.Name)
 			}
@@ -73,7 +73,7 @@ func Test_Options(t *testing.T) {
 				t.Fatalf("getting options: %v", err)
 			}
 
-			if licensekey := options.InfraAgentInjection.License; licensekey != expectedLicenseKey {
+			if licensekey := options.KubernetesIntegrationInjection.License; licensekey != expectedLicenseKey {
 				t.Fatalf("expected license key %q, got %q", expectedLicenseKey, licensekey)
 			}
 		})
@@ -95,7 +95,7 @@ infraAgentInjection:
 				t.Fatalf("getting options: %v", err)
 			}
 
-			if clusterName := options.InfraAgentInjection.ClusterName; clusterName != expectedClusterName {
+			if clusterName := options.KubernetesIntegrationInjection.ClusterName; clusterName != expectedClusterName {
 				t.Fatalf("expected cluster name %q, got %q", expectedClusterName, clusterName)
 			}
 		})
@@ -112,7 +112,7 @@ infraAgentInjection:
 				t.Fatalf("getting options: %v", err)
 			}
 
-			if clusterName := options.InfraAgentInjection.ClusterName; clusterName != expectedClusterName {
+			if clusterName := options.KubernetesIntegrationInjection.ClusterName; clusterName != expectedClusterName {
 				t.Fatalf("expected cluster name %q, got %q", expectedClusterName, clusterName)
 			}
 		})

--- a/internal/mutator/pod/agent/agent_config.go
+++ b/internal/mutator/pod/agent/agent_config.go
@@ -40,3 +40,12 @@ type ConfigSelector struct {
 	selector labels.Selector `json:"-"`
 	hash     string          `json:"-"`
 }
+
+// InfraAgentConfig holds the user's configuration for the sidecar to be injected.
+type KubeletConfig struct {
+	// Here we can map the whole user configuration from helm chart.
+	ConfigSelectors    []ConfigSelector   `json:"configSelectors"`
+	ScraperConfig      string             `json:"scraperConfigToInject"`
+	Image              Image              `json:"image"`
+	PodSecurityContext PodSecurityContext `json:"podSecurityContext"`
+}

--- a/internal/mutator/pod/agent/config_map.go
+++ b/internal/mutator/pod/agent/config_map.go
@@ -1,0 +1,78 @@
+// Copyright 2022 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package agent
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	kubeletCMName = "newrelic-kubelet-scraper-config"
+)
+
+// ensureConfigMapExistence assures that the kubelet configMap exists and it is well configured, otherwise patches the
+// existing object or create a new one.
+func (i *injector) ensureConfigMapExistence(ctx context.Context, namespace string) error {
+	cm := &corev1.ConfigMap{}
+	key := client.ObjectKey{
+		Namespace: namespace,
+		Name:      kubeletCMName,
+	}
+
+	err := i.noCacheClient.Get(ctx, key, cm)
+
+	if apierrors.IsNotFound(err) {
+		return i.createConfigMap(ctx, namespace)
+	}
+
+	if err != nil {
+		return fmt.Errorf("getting cm in the cluster %s/%s: %w", namespace, kubeletCMName, err)
+	}
+
+	if !reflect.DeepEqual(cm.BinaryData, i.kubeletConfig) {
+		return i.updateConfigMap(ctx, cm)
+	}
+
+	return nil
+}
+
+func (i *injector) createConfigMap(ctx context.Context, namespace string) error {
+	s := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      i.licenseSecretName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				OperatorCreatedLabel: OperatorCreatedLabelValue,
+			},
+		},
+		Data: map[string][]byte{
+			LicenseSecretKey: i.license,
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+
+	if err := i.noCacheClient.Create(ctx, s, &client.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("creating secret %s/%s: %w", s.Namespace, s.Name, err)
+	}
+
+	return nil
+}
+
+func (i *injector) updateConfigMap(ctx context.Context, s *corev1.ConfigMap) error {
+	// When we update we should not add the label since likely the user or a different newrelic installation created
+	// such secret.
+	s.BinaryData = i.kubeletConfig
+	if err := i.noCacheClient.Update(ctx, s, &client.UpdateOptions{}); err != nil {
+		return fmt.Errorf("updating secret: %w", err)
+	}
+
+	return nil
+}

--- a/internal/mutator/pod/agent/injector.go
+++ b/internal/mutator/pod/agent/injector.go
@@ -73,7 +73,7 @@ type injector struct {
 	noCacheClient client.Client
 }
 
-// InjectorConfig of the Injector used to pass the required data to build it.
+// InjectorConfig of the Mutator used to pass the required data to build it.
 type InjectorConfig struct {
 	AgentConfig    InfraAgentConfig  `json:"agentConfig"`
 	ResourcePrefix string            `json:"resourcePrefix"`
@@ -133,14 +133,14 @@ func (cas CustomAttributes) toString(podLabels map[string]string) (string, error
 	return string(casRaw), nil
 }
 
-// Injector injects New Relic infrastructure-agent into given pod, ensuring that it has all capabilities to run
+// Mutator injects New Relic infrastructure-agent into given pod, ensuring that it has all capabilities to run
 // like right permissions and access to the New Relic license key.
-type Injector interface {
+type Mutator interface {
 	Mutate(ctx context.Context, pod *corev1.Pod, requestOptions webhook.RequestOptions) error
 }
 
 // New function is the constructor for the injector struct.
-func (config InjectorConfig) New(client, noCacheClient client.Client, logger *logrus.Logger) (Injector, error) {
+func (config InjectorConfig) New(client, noCacheClient client.Client, logger *logrus.Logger) (Mutator, error) {
 	config.AgentConfig.CustomAttributes = append(config.AgentConfig.CustomAttributes, CustomAttribute{
 		Name:         clusterNameAttribute,
 		DefaultValue: config.ClusterName,

--- a/internal/mutator/pod/agent/injector_test.go
+++ b/internal/mutator/pod/agent/injector_test.go
@@ -213,7 +213,7 @@ func Test_Mutate(t *testing.T) {
 			t.Parallel()
 
 			if len(p.Spec.Containers) != 2 {
-				t.Fatalf("expected extra container to be added, got %v", cmp.Diff(getEmptyPod(), p))
+				t.Fatalf("expected extra agentContainer to be added, got %v", cmp.Diff(getEmptyPod(), p))
 			}
 		})
 
@@ -566,7 +566,7 @@ func Test_Mutate(t *testing.T) {
 			t.Parallel()
 
 			if len(p.Spec.Containers) != 2 {
-				t.Fatalf("expected extra container to be added, got %v", cmp.Diff(getEmptyPod(), p))
+				t.Fatalf("expected extra agentContainer to be added, got %v", cmp.Diff(getEmptyPod(), p))
 			}
 		})
 
@@ -885,7 +885,7 @@ func Test_Mutate(t *testing.T) {
 					t.Fatalf("mutating Pod: %v", err)
 				}
 
-				expectedContainers := 2
+				expectedContainers := 3
 
 				if len(p.Spec.Containers) != expectedContainers {
 					t.Fatalf("expected %d containers, got %d: %v", expectedContainers, len(p.Spec.Containers), p.Spec.Containers)
@@ -1232,7 +1232,7 @@ func Test_Mutation_hash(t *testing.T) {
 		Namespace: testNamespace,
 	}
 
-	// This also tests that all configurable knobs are included included into container as we hash
+	// This also tests that all configurable knobs are included included into agentContainer as we hash
 	// entire sidecar configuration.
 	t.Run("changes_when", func(t *testing.T) {
 		t.Parallel()
@@ -1346,7 +1346,7 @@ func Test_Mutation_hash(t *testing.T) {
 
 		p2 := getEmptyPod()
 		p2.Labels["newLabel"] = "newValue"
-		p2.Spec.Containers = append(p2.Spec.Containers, corev1.Container{Name: "test-container"})
+		p2.Spec.Containers = append(p2.Spec.Containers, corev1.Container{Name: "test-agentContainer"})
 
 		if err := i.Mutate(ctx, p2, req); err != nil {
 			t.Fatalf("mutating second pod: %v", err)
@@ -1372,7 +1372,7 @@ func infraContainer(t *testing.T, pod *corev1.Pod) corev1.Container {
 		}
 	}
 
-	t.Fatalf("infra container %q not found", agent.AgentSidecarName)
+	t.Fatalf("infra agentContainer %q not found", agent.AgentSidecarName)
 
 	return corev1.Container{}
 }

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -37,7 +37,7 @@ type Options struct {
 	Logger                 *logrus.Logger `json:"-"`
 	IgnoreMutationErrors   bool           `json:"ignoreMutationErrors"`
 
-	InfraAgentInjection agent.InjectorConfig `json:"infraAgentInjection"`
+	KubernetesIntegrationInjection agent.InjectorConfig `json:"infraAgentInjection"`
 }
 
 // Run starts operator main loop. At the moment it only runs TLS webhook server and healthcheck web server.
@@ -75,7 +75,7 @@ func Run(ctx context.Context, options Options) error {
 		return fmt.Errorf("creating client: %w", err)
 	}
 
-	agentInjector, err := options.InfraAgentInjection.New(mgr.GetClient(), noCacheClient, options.Logger)
+	agentInjector, err := options.KubernetesIntegrationInjection.New(mgr.GetClient(), noCacheClient, options.Logger)
 	if err != nil {
 		return fmt.Errorf("creating injector: %w", err)
 	}

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -84,7 +84,7 @@ func Run(ctx context.Context, options Options) error {
 		Handler: &podMutatorHandler{
 			ignoreMutationErrors: options.IgnoreMutationErrors,
 			logger:               options.Logger,
-			mutators: []podMutator{
+			mutators: []agent.Mutator{
 				agentInjector,
 			},
 		},

--- a/internal/operator/operator_integration_test.go
+++ b/internal/operator/operator_integration_test.go
@@ -416,7 +416,7 @@ func testOptions(t *testing.T, cfg *rest.Config, certDir string) operator.Option
 		HealthProbeBindAddress: fmt.Sprintf("%s:%d", testHost, randomUnprivilegedPort(t)),
 		MetricsBindAddress:     fmt.Sprintf("%s:%d", testHost, randomUnprivilegedPort(t)),
 		Port:                   randomUnprivilegedPort(t),
-		InfraAgentInjection: agent.InjectorConfig{
+		KubernetesIntegrationInjection: agent.InjectorConfig{
 			AgentConfig: agent.InfraAgentConfig{
 				Image: agent.Image{
 					Repository: "test-repository",

--- a/internal/operator/pod_mutator_handler.go
+++ b/internal/operator/pod_mutator_handler.go
@@ -6,6 +6,7 @@ package operator
 import (
 	"context"
 	"encoding/json"
+	"github.com/newrelic/newrelic-infra-operator/internal/mutator/pod/agent"
 	"net/http"
 
 	"github.com/sirupsen/logrus"
@@ -15,13 +16,9 @@ import (
 	"github.com/newrelic/newrelic-infra-operator/internal/webhook"
 )
 
-type podMutator interface {
-	Mutate(ctx context.Context, pod *corev1.Pod, requestOptions webhook.RequestOptions) error
-}
-
 type podMutatorHandler struct {
 	decoder              *admission.Decoder
-	mutators             []podMutator
+	mutators             []agent.Mutator
 	ignoreMutationErrors bool
 	logger               *logrus.Logger
 }

--- a/internal/operator/pod_mutator_handler_internal_test.go
+++ b/internal/operator/pod_mutator_handler_internal_test.go
@@ -6,6 +6,7 @@ package operator
 import (
 	"context"
 	"fmt"
+	"github.com/newrelic/newrelic-infra-operator/internal/mutator/pod/agent"
 	"net/http"
 	"testing"
 
@@ -46,7 +47,7 @@ func Test_Pod_mutator_handle(t *testing.T) {
 
 		handler := newHandler(t)
 
-		handler.mutators = []podMutator{
+		handler.mutators = []agent.Mutator{
 			&mockMutator{
 				mutateF: func(_ context.Context, pod *corev1.Pod, _ webhook.RequestOptions) error {
 					pod.Labels = map[string]string{"foo": "bar"}
@@ -75,7 +76,7 @@ func Test_Pod_mutator_handle(t *testing.T) {
 		handler := newHandler(t)
 		handler.ignoreMutationErrors = true
 
-		handler.mutators = []podMutator{
+		handler.mutators = []agent.Mutator{
 			&mockMutator{
 				mutateF: func(_ context.Context, pod *corev1.Pod, _ webhook.RequestOptions) error {
 					return fmt.Errorf("test error")
@@ -119,7 +120,7 @@ func Test_Pod_mutator_handle(t *testing.T) {
 		t.Run("one_of_the_mutators_returns_error", func(t *testing.T) {
 			handler := newHandler(t)
 
-			handler.mutators = []podMutator{
+			handler.mutators = []agent.Mutator{
 				&mockMutator{
 					mutateF: func(_ context.Context, _ *corev1.Pod, _ webhook.RequestOptions) error {
 						return nil

--- a/values-dev.yaml
+++ b/values-dev.yaml
@@ -7,75 +7,14 @@ restartPolicy: Never
 
 # Temporary extra values, required by newrelic-infra-operator chart.
 cluster: testing
-licenseKey: stub
+licenseKey: TEST
 
 config:
   infraAgentInjection:
     policies:
-    - {}
-    agentConfig:
-      image:
-        repository: newrelic/infrastructure-k8s
-        tag: 2.4.0-unprivileged
-        pullPolicy: IfNotPresent
-      customAttributes:
-        - name: computeType
-          defaultValue: serverless
-        - name: fargateProfile
-          # To allow inclusion on non-fargate clusters for testing.
-          defaultValue: unknown
-          fromLabel: eks.amazonaws.com/fargate-profile
-      configSelectors:
-        - labelSelector:
-            matchLabels:
-              no-resources: true
-        - resourceRequirements:
-            limits:
-              memory: 100M
-              cpu: 200m
-            requests:
-              memory: 50M
-              cpu: 100m
-          ExtraEnvVars:
-            DISABLE_KUBE_STATE_METRICS: "true"
-          labelSelector:
-            matchExpressions:
-              - key: "app.kubernetes.io/name"
-                operator: NotIn
-                values: ["kube-state-metrics"]
-              - key: "app"
-                operator: NotIn
-                values: ["kube-state-metrics"]
-              - key: "k8s-app"
-                operator: NotIn
-                values: ["kube-state-metrics"]
-        - resourceRequirements:
-            limits:
-              memory: 300M
-              cpu: 300m
-            requests:
-              memory: 150M
-              cpu: 150m
-          labelSelector:
-            matchLabels:
-              k8s-app : kube-state-metrics
-        - resourceRequirements:
-            limits:
-              memory: 300M
-              cpu: 300m
-            requests:
-              memory: 150M
-              cpu: 150m
-          labelSelector:
-            matchLabels:
-              app : kube-state-metrics
-        - resourceRequirements:
-            limits:
-              memory: 300M
-              cpu: 300m
-            requests:
-              memory: 150M
-              cpu: 150m
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/name: kube-state-metrics
+      - {}
+
+
+global:
+  podLabels:
+    "infra-operator.newrelic.com/disable-injection": "true"


### PR DESCRIPTION
This Pr shows a possible approach to implementing V3 architecture in the old operator.

It is clearly working in progress, but currently being able to inject 2 containers and to control the lifecycle of the configMap having the configuration.

Note that this would inject 2 sidecars instead of 1. However, the footprint is comparable and we are going to move from 2 processes in one container to one process per container. This has several benefits:
It will popup issues in a clearer way, logs will be easier to be checked, ksm will be not anymore in the picture since it will be scraped by a separate deployment making configuration easier to manage
