### PR TITLE
NEWRELIC-3912 Add nodeSelector support for jobs 

### DIFF
--- a/charts/newrelic-infra-operator/Chart.yaml
+++ b/charts/newrelic-infra-operator/Chart.yaml
@@ -7,7 +7,7 @@ sources:
   - https://github.com/newrelic/newrelic-infra-operator
   - https://github.com/newrelic/newrelic-infra-operator/tree/main/charts/newrelic-infra-operator
 
-version: 1.0.8
+version: 1.0.9
 appVersion: 0.6.0
 
 dependencies:

--- a/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -47,6 +47,10 @@ spec:
         runAsGroup: 2000
         runAsNonRoot: true
         runAsUser: 2000
+      {{- with include "newrelic.common.nodeSelector" . }}
+      nodeSelector:
+        {{- . | nindent 8 -}}
+      {{- end }}
       {{- with include "newrelic.common.tolerations" . }}
       tolerations:
         {{- . | nindent 8 -}}

--- a/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -47,6 +47,10 @@ spec:
         runAsGroup: 2000
         runAsNonRoot: true
         runAsUser: 2000
+      {{- with include "newrelic.common.nodeSelector" . }}
+      nodeSelector:
+        {{- . | nindent 8 -}}
+      {{- end }}
       {{- with include "newrelic.common.tolerations" . }}
       tolerations:
         {{- . | nindent 8 -}}


### PR DESCRIPTION
Relates to https://github.com/newrelic/helm-charts/issues/932.

NodeSelectors are not being honoured in the jobs objects.