### PR TITLE
Disables PSP by default for New Relic  Infra Operator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        kubernetes-version: [ "v1.17.17", "v1.22.0" ]
+        kubernetes-version: [ "v1.17.17", "v1.22.0", "v1.25.3" ]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -47,7 +47,7 @@ jobs:
         uses: manusa/actions-setup-minikube@v2.7.0
         if: steps.list-changed.outputs.changed == 'true'
         with:
-          minikube version: v1.20.0
+          minikube version: v1.27.1
           kubernetes version: ${{ matrix.kubernetes-version }}
           github token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-go@v3

--- a/charts/newrelic-infra-operator/Chart.yaml
+++ b/charts/newrelic-infra-operator/Chart.yaml
@@ -7,7 +7,7 @@ sources:
   - https://github.com/newrelic/newrelic-infra-operator
   - https://github.com/newrelic/newrelic-infra-operator/tree/main/charts/newrelic-infra-operator
 
-version: 1.0.11
+version: 2.0.0
 appVersion: 0.7.0
 
 dependencies:

--- a/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/clusterrole.yaml
+++ b/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/clusterrole.yaml
@@ -17,9 +17,11 @@ rules:
     verbs:
       - get
       - update
+{{- if .Values.rbac.pspEnabled }}
   - apiGroups: ['policy']
     resources: ['podsecuritypolicies']
     verbs: ['use']
     resourceNames:
     - {{ include "newrelic-infra-operator.fullname.admission" . }}
+{{- end }}
 {{- end }}

--- a/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/psp.yaml
+++ b/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/psp.yaml
@@ -1,4 +1,4 @@
-{{- if (and (not .Values.customTLSCertificate) (not .Values.certManager.enabled)) }}
+{{- if (and (not .Values.customTLSCertificate) (not .Values.certManager.enabled) (.Values.rbac.pspEnabled)) }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/newrelic-infra-operator/values.yaml
+++ b/charts/newrelic-infra-operator/values.yaml
@@ -43,7 +43,7 @@ admissionWebhooksPatchJob:
   volumes: []
   # - name: tmp
   #   emptyDir: {}
-  
+
 rbac:
   # rbac.pspEnabled -- Whether the chart should create Pod Security Policy objects.
   pspEnabled: false

--- a/charts/newrelic-infra-operator/values.yaml
+++ b/charts/newrelic-infra-operator/values.yaml
@@ -43,6 +43,10 @@ admissionWebhooksPatchJob:
   volumes: []
   # - name: tmp
   #   emptyDir: {}
+  
+rbac:
+  # rbac.pspEnabled -- Whether the chart should create Pod Security Policy objects.
+  pspEnabled: false
 
 replicas: 1
 


### PR DESCRIPTION
PSPs are removed in K8s v1.25. Attempting to install this chart in 1.25 will result in an error as the followings:

```
vtran@WG2QKVH662 newrelic-infra-operator % helm upgrade --install newrelic-infra-operator -f ./ci/test-values.yaml . --debug
history.go:56: [debug] getting history for release newrelic-infra-operator
Release "newrelic-infra-operator" does not exist. Installing it now.
install.go:192: [debug] Original chart version: ""
install.go:209: [debug] CHART PATH: /Users/vtran/Desktop/Work/newrelic-infra-operator/charts/newrelic-infra-operator

Error: failed pre-install: unable to build kubernetes object for deleting hook newrelic-infra-operator/templates/admission-webhooks/job-patch/psp.yaml: resource mapping not found for name: "newrelic-infra-operator-admission" namespace: "" from "": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1"
ensure CRDs are installed first
helm.go:84: [debug] failed pre-install: unable to build kubernetes object for deleting hook newrelic-infra-operator/templates/admission-webhooks/job-patch/psp.yaml: resource mapping not found for name: "newrelic-infra-operator-admission" namespace: "" from "": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1"
ensure CRDs are installed first
```

This PR adds a flag to control whether PSPs should be created and disables it by default. Manually testing the change on a k8s v1.25.3 minikube, no more errors as describing above. See the the following output from my testing.

```
vtran@WG2QKVH662 newrelic-infra-operator % helm upgrade --install newrelic-infra-operator -f ./ci/test-values.yaml .
W1118 14:06:37.277820    6772 warnings.go:70] spec.template.spec.nodeSelector[beta.kubernetes.io/os]: deprecated since v1.14; use "kubernetes.io/os" instead
W1118 14:06:44.262002    6772 warnings.go:70] spec.template.spec.nodeSelector[beta.kubernetes.io/os]: deprecated since v1.14; use "kubernetes.io/os" instead
W1118 14:06:44.447842    6772 warnings.go:70] spec.template.spec.nodeSelector[beta.kubernetes.io/os]: deprecated since v1.14; use "kubernetes.io/os" instead
Release "newrelic-infra-operator" has been upgraded. Happy Helming!
NAME: newrelic-infra-operator
LAST DEPLOYED: Fri Nov 18 14:06:37 2022
NAMESPACE: default
STATUS: deployed
REVISION: 4
TEST SUITE: None
NOTES:
Your deployment of the New Relic Infrastructure Operator is complete.
You can check on the progress of this by running the following command:

    kubectl get deployments -o wide -w --namespace default newrelic-infra-operator
```


