### PR TITLE
chore(semgrep): fix rules and ignore what is not fixable or relevant

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -5,8 +5,9 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
-	"io/ioutil"
+	"io/fs"
 	"os"
 
 	"sigs.k8s.io/yaml"
@@ -32,8 +33,8 @@ const (
 func Options(path string) (*operator.Options, error) {
 	options := &operator.Options{}
 
-	optionsBytes, err := ioutil.ReadFile(path)
-	if err != nil && !os.IsNotExist(err) {
+	optionsBytes, err := os.ReadFile(path)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return nil, fmt.Errorf("reading configuration file %q: %w", path, err)
 	}
 

--- a/internal/mutator/pod/agent/injector.go
+++ b/internal/mutator/pod/agent/injector.go
@@ -618,13 +618,14 @@ func getAgentPassthroughEnvironment() string {
 	return strings.Join(flags, ",")
 }
 
+//nolint:gosec
 func (c configHash) calculate() (string, error) {
 	b, err := yaml.Marshal(c)
 	if err != nil {
 		return "", fmt.Errorf("marshalling input: %w", err)
 	}
 
-	h := sha1.New()
+	h := sha1.New() // nosemgrep
 	h.Write(b)
 
 	return fmt.Sprintf("%x", h.Sum(nil)), nil

--- a/internal/testutil/util.go
+++ b/internal/testutil/util.go
@@ -24,7 +24,7 @@ func ContextWithDeadline(t *testing.T) context.Context {
 		return context.Background()
 	}
 
-	ctx, cancel := context.WithDeadline(context.Background(), deadline.Truncate(timeoutGracePeriod))
+	ctx, cancel := context.WithDeadline(context.Background(), deadline.Truncate(timeoutGracePeriod)) // nosemgrep
 
 	t.Cleanup(cancel)
 


### PR DESCRIPTION
We could easily change this to a sha256, but it would cause a re-deploy in all customer environments with basically no benefit for the user since we use it just to check if the config did not change

Canceling the context is also already done with the t.cleanup(), therefore it is a false positive