### PR TITLE
Remove dependabot limits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 3
   - package-ecosystem: docker
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 1
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 2


### PR DESCRIPTION
This lets dependabot open upto 5 PRs per type.
