### PR TITLE
Unlink chart releases from updates

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -5,3 +5,6 @@ target-branch: main
 
 chart-repos:
   - newrelic=https://helm-charts.newrelic.com
+
+# Charts will be released manually.
+check-version-increment: false

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -40,4 +40,5 @@ jobs:
       - name: Release workload charts
         uses: helm/chart-releaser-action@v1.5.0
         env:
+          CR_SKIP_EXISTING: true
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This lets us update charts without needing to bump the 
version and release them in the same PR.
