### PR TITLE
Bump infrastructure-k8s version from 2.13.5 to 2.13.6

### DIFF
--- a/charts/newrelic-infra-operator/values.yaml
+++ b/charts/newrelic-infra-operator/values.yaml
@@ -140,7 +140,7 @@ config:
       # @default -- See `values.yaml`
       image:
         repository: newrelic/infrastructure-k8s
-        tag: 2.13.5-unprivileged
+        tag: 2.13.6-unprivileged
         pullPolicy: IfNotPresent
 
       # -- configSelectors is the way to configure resource requirements and extra envVars of the injected sidecar container.

--- a/values-dev.yaml
+++ b/values-dev.yaml
@@ -16,7 +16,7 @@ config:
     agentConfig:
       image:
         repository: newrelic/infrastructure-k8s
-        tag: 2.13.5-unprivileged
+        tag: 2.13.6-unprivileged
         pullPolicy: IfNotPresent
       customAttributes:
         - name: computeType


### PR DESCRIPTION
A new image was recently released: https://hub.docker.com/r/newrelic/infrastructure-k8s/tags