### PR TITLE
Update K8s Versions in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        kubernetes-version: [ "v1.17.17", "v1.22.0", "v1.25.3" ]
+        kubernetes-version: ["v1.23.17", "1.24.17", "1.25.13", "1.26.8", "1.27.5"]
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Which problem is this PR solving?

Update E2E tests and E2E exceptions


## Short description of the changes

check the GitHub workflows that run for PR pushes and:

Remove any references to Kubernetes versions 1.22 or older
Add to tests Kubernetes versions: 1.23.17, 1.24.17, 1.25.13, 1.26.8, 1.27.5

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## New Tests?
update exist testing workflow

## Checklist:

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Tests have been added
