### PR TITLE
ci: Refactor `changelog` workflow to use reusable workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,33 +5,8 @@ name: changelog
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
-  changelog-entry:
-    runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog')}}
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Check for CHANGELOG file changes
-        run: |
-          # Only the latest commit of the feature branch is available
-          # automatically. To diff with the base branch, we need to
-          # fetch that too (and we only need its latest commit).
-          git fetch origin ${{ github.base_ref }} --depth=1
-          if [[ $(git diff --name-only FETCH_HEAD | grep --ignore-case CHANGELOG) ]]
-          then
-            echo "The CHANGELOG file was modified. Looks good!"
-          else
-            echo "The CHANGELOG file was not modified."
-            echo "Please add a CHANGELOG entry to the appropriate header under \"Unreleased\", or add the \"Skip Changelog\" label if not required."
-            false
-          fi
-  lint-changelog:
-    runs-on: ubuntu-latest
-    needs: changelog-entry
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Check if CHANGELOG is valid
-        uses: newrelic/release-toolkit/validate-markdown@v1
+  check-changelog:
+    uses: newrelic/k8s-metadata-injection/.github/workflows/changelog-reusable.yml@main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### bugfix
 - Fix bug reported in [NR-153839](https://issues.newrelic.com/browse/NR-153839) by @juanjjaramillo in [#319](https://github.com/newrelic/newrelic-infra-operator/pull/319)
 ### enhancement
-- Update k8s versions in CI by @xqi-nr in https://github.com/newrelic/newrelic-infra-operator/pull/323
+- Update k8s versions in CI by @xqi-nr in [#323](https://github.com/newrelic/newrelic-infra-operator/pull/323)
+- Refactor `changelog` workflow to use reusable workflow by @juanjjaramillo in [#339](https://github.com/newrelic/newrelic-infra-operator/pull/339)
 
 ## [0.10.2]
 


### PR DESCRIPTION
## Which problem is this PR solving?
In order to simplify maintenance and avoid duplication, `changelog` workflow is now using a reusable workflow

## Type of change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Security fix
- [x] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## New Tests?
Please describe the new tests that were added (if applicable).

- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] e2e tests

## Checklist:

- [x] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Tests have been added
- [ ] Documentation has been updated