### PR TITLE
feat: add global.images registry, pullSecrets, and pullPolicy support to newrelic-infra-operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### enhancement
+- Add global.images registry, pullSecrets, and pullPolicy support @dpacheconr [#603](https://github.com/newrelic/newrelic-infra-operator/pull/603)
+
 ## v0.26.7 - 2026-03-09
 
 ### ⛓️ Dependencies
@@ -66,14 +69,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v0.25.0 - 2025-10-13
 
-### dependency
-- Updated k8s.io/api, k8s.io/apimachinery, k8s.io/client-go to v0.34.1 @TmNguyen12 [#590](https://github.com/newrelic/newrelic-infra-operator/pull/590)
-
 ### 🚀 Enhancements
 - Add support for k8s v1.34.0, remove support for v1.29.5 @TmNguyen12 [#590](https://github.com/newrelic/newrelic-infra-operator/pull/590)
 
 ### ⛓️ Dependencies
 - Updated alpine to v3.22.2
+- Updated k8s.io/api, k8s.io/apimachinery, k8s.io/client-go to v0.34.1 @TmNguyen12 [#590](https://github.com/newrelic/newrelic-infra-operator/pull/590)
 
 ## v0.24.0 - 2025-09-29
 

--- a/charts/newrelic-infra-operator/templates/_helpers.tpl
+++ b/charts/newrelic-infra-operator/templates/_helpers.tpl
@@ -135,7 +135,7 @@ Returns the sidecar image repository, respecting global.images.registry
 {{- $imageRepository := .Values.config.infraAgentInjection.agentConfig.image.repository -}}
 {{- $defaultRepository := "newrelic/infrastructure-k8s" -}}
 {{- $registry := "" -}}
-{{- if .Values.global }}
+{{- if and .Values.global .Values.global.images }}
   {{- $registry = .Values.global.images.registry | default "" -}}
 {{- end -}}
 {{- if and $registry (eq $imageRepository $defaultRepository) -}}
@@ -159,7 +159,10 @@ Returns configmap data
 Returns the pull policy for operator image, respecting global.images.pullPolicy
 */}}
 {{- define "newrelic-infra-operator.imagePullPolicy" -}}
-{{- $globalPullPolicy := .Values.global.images.pullPolicy | default "" -}}
+{{- $globalPullPolicy := "" -}}
+{{- if and .Values.global .Values.global.images }}
+  {{- $globalPullPolicy = .Values.global.images.pullPolicy | default "" -}}
+{{- end -}}
 {{- $chartPullPolicy := .Values.image.pullPolicy | default "" -}}
 {{- if $globalPullPolicy -}}
   {{- $globalPullPolicy -}}
@@ -174,7 +177,10 @@ Returns the pull policy for operator image, respecting global.images.pullPolicy
 Returns the pull policy for admission webhooks patch job image, respecting global.images.pullPolicy
 */}}
 {{- define "newrelic-infra-operator.admissionWebhooksPatchJob.imagePullPolicy" -}}
-{{- $globalPullPolicy := .Values.global.images.pullPolicy | default "" -}}
+{{- $globalPullPolicy := "" -}}
+{{- if and .Values.global .Values.global.images }}
+  {{- $globalPullPolicy = .Values.global.images.pullPolicy | default "" -}}
+{{- end -}}
 {{- $chartPullPolicy := .Values.admissionWebhooksPatchJob.image.pullPolicy | default "" -}}
 {{- if $globalPullPolicy -}}
   {{- $globalPullPolicy -}}

--- a/charts/newrelic-infra-operator/templates/_helpers.tpl
+++ b/charts/newrelic-infra-operator/templates/_helpers.tpl
@@ -154,3 +154,33 @@ Returns configmap data
 {{- $_ := set $config.infraAgentInjection.agentConfig.image "repository" $sidecarImage -}}
 {{ toYaml $config }}
 {{- end }}
+
+{{/*
+Returns the pull policy for operator image, respecting global.images.pullPolicy
+*/}}
+{{- define "newrelic-infra-operator.imagePullPolicy" -}}
+{{- $globalPullPolicy := .Values.global.images.pullPolicy | default "" -}}
+{{- $chartPullPolicy := .Values.image.pullPolicy | default "" -}}
+{{- if $globalPullPolicy -}}
+  {{- $globalPullPolicy -}}
+{{- else if $chartPullPolicy -}}
+  {{- $chartPullPolicy -}}
+{{- else -}}
+  IfNotPresent
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns the pull policy for admission webhooks patch job image, respecting global.images.pullPolicy
+*/}}
+{{- define "newrelic-infra-operator.admissionWebhooksPatchJob.imagePullPolicy" -}}
+{{- $globalPullPolicy := .Values.global.images.pullPolicy | default "" -}}
+{{- $chartPullPolicy := .Values.admissionWebhooksPatchJob.image.pullPolicy | default "" -}}
+{{- if $globalPullPolicy -}}
+  {{- $globalPullPolicy -}}
+{{- else if $chartPullPolicy -}}
+  {{- $chartPullPolicy -}}
+{{- else -}}
+  IfNotPresent
+{{- end -}}
+{{- end -}}

--- a/charts/newrelic-infra-operator/templates/_helpers.tpl
+++ b/charts/newrelic-infra-operator/templates/_helpers.tpl
@@ -133,13 +133,15 @@ Returns the sidecar image repository, respecting global.images.registry
 */}}
 {{- define "newrelic-infra-operator.sidecar.image" -}}
 {{- $imageRepository := .Values.config.infraAgentInjection.agentConfig.image.repository -}}
-{{- $defaultRepository := "newrelic/infrastructure-k8s" -}}
-{{- $registry := "" -}}
+{{- $globalRegistry := "" -}}
 {{- if and .Values.global .Values.global.images }}
-  {{- $registry = .Values.global.images.registry | default "" -}}
+  {{- $globalRegistry = .Values.global.images.registry | default "" -}}
 {{- end -}}
-{{- if $registry -}}
-  {{- printf "%s/%s" $registry $imageRepository -}}
+{{- $chartRegistry := .Values.config.infraAgentInjection.agentConfig.image.registry | default "" -}}
+{{- if $chartRegistry -}}
+  {{- printf "%s/%s" $chartRegistry $imageRepository -}}
+{{- else if $globalRegistry -}}
+  {{- printf "%s/%s" $globalRegistry $imageRepository -}}
 {{- else -}}
   {{- $imageRepository -}}
 {{- end -}}
@@ -149,11 +151,31 @@ Returns the sidecar image repository, respecting global.images.registry
 Returns configmap data
 */}}
 {{- define "newrelic-infra-operator.configmap.data" -}}
-{{- $config := (merge (include "newrelic-infra-operator.fargate-config" . | fromYaml) .Values.config) -}}
+{{- $config := (merge (include "newrelic-infra-operator.fargate-config" . | fromYaml) (deepCopy .Values.config)) -}}
 {{- $sidecarImage := include "newrelic-infra-operator.sidecar.image" . -}}
 {{- $_ := set $config.infraAgentInjection.agentConfig.image "repository" $sidecarImage -}}
+{{- $sidecarPullPolicy := include "newrelic-infra-operator.sidecar.imagePullPolicy" . -}}
+{{- $_ := set $config.infraAgentInjection.agentConfig.image "pullPolicy" $sidecarPullPolicy -}}
 {{ toYaml $config }}
 {{- end }}
+
+{{/*
+Returns the pull policy for sidecar image, respecting global.images.pullPolicy
+*/}}
+{{- define "newrelic-infra-operator.sidecar.imagePullPolicy" -}}
+{{- $globalPullPolicy := "" -}}
+{{- if and .Values.global .Values.global.images }}
+  {{- $globalPullPolicy = .Values.global.images.pullPolicy | default "" -}}
+{{- end -}}
+{{- $chartPullPolicy := .Values.config.infraAgentInjection.agentConfig.image.pullPolicy | default "" -}}
+{{- if $chartPullPolicy -}}
+  {{- $chartPullPolicy -}}
+{{- else if $globalPullPolicy -}}
+  {{- $globalPullPolicy -}}
+{{- else -}}
+  IfNotPresent
+{{- end -}}
+{{- end -}}
 
 {{/*
 Returns the pull policy for operator image, respecting global.images.pullPolicy

--- a/charts/newrelic-infra-operator/templates/_helpers.tpl
+++ b/charts/newrelic-infra-operator/templates/_helpers.tpl
@@ -156,6 +156,7 @@ Returns configmap data
 {{- $_ := set $config.infraAgentInjection.agentConfig.image "repository" $sidecarImage -}}
 {{- $sidecarPullPolicy := include "newrelic-infra-operator.sidecar.imagePullPolicy" . -}}
 {{- $_ := set $config.infraAgentInjection.agentConfig.image "pullPolicy" $sidecarPullPolicy -}}
+{{- $_ := unset $config.infraAgentInjection.agentConfig.image "registry" -}}
 {{ toYaml $config }}
 {{- end }}
 

--- a/charts/newrelic-infra-operator/templates/_helpers.tpl
+++ b/charts/newrelic-infra-operator/templates/_helpers.tpl
@@ -138,8 +138,8 @@ Returns the sidecar image repository, respecting global.images.registry
 {{- if and .Values.global .Values.global.images }}
   {{- $registry = .Values.global.images.registry | default "" -}}
 {{- end -}}
-{{- if and $registry (eq $imageRepository $defaultRepository) -}}
-  {{- printf "%s/%s" $registry $defaultRepository -}}
+{{- if $registry -}}
+  {{- printf "%s/%s" $registry $imageRepository -}}
 {{- else -}}
   {{- $imageRepository -}}
 {{- end -}}
@@ -164,10 +164,10 @@ Returns the pull policy for operator image, respecting global.images.pullPolicy
   {{- $globalPullPolicy = .Values.global.images.pullPolicy | default "" -}}
 {{- end -}}
 {{- $chartPullPolicy := .Values.image.pullPolicy | default "" -}}
-{{- if $globalPullPolicy -}}
-  {{- $globalPullPolicy -}}
-{{- else if $chartPullPolicy -}}
+{{- if $chartPullPolicy -}}
   {{- $chartPullPolicy -}}
+{{- else if $globalPullPolicy -}}
+  {{- $globalPullPolicy -}}
 {{- else -}}
   IfNotPresent
 {{- end -}}
@@ -182,10 +182,10 @@ Returns the pull policy for admission webhooks patch job image, respecting globa
   {{- $globalPullPolicy = .Values.global.images.pullPolicy | default "" -}}
 {{- end -}}
 {{- $chartPullPolicy := .Values.admissionWebhooksPatchJob.image.pullPolicy | default "" -}}
-{{- if $globalPullPolicy -}}
-  {{- $globalPullPolicy -}}
-{{- else if $chartPullPolicy -}}
+{{- if $chartPullPolicy -}}
   {{- $chartPullPolicy -}}
+{{- else if $globalPullPolicy -}}
+  {{- $globalPullPolicy -}}
 {{- else -}}
   IfNotPresent
 {{- end -}}

--- a/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -18,15 +18,14 @@ spec:
         app: {{ include "newrelic-infra-operator.name.admission-create" . }}
         {{- include "newrelic.common.labels.podLabels" . | nindent 8 }}
     spec:
-      {{- $globalPullSecrets := .Values.global.images.pullSecrets | default list }}
-      {{- with include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" ( concat $globalPullSecrets (list .Values.admissionWebhooksPatchJob.image.pullSecrets) ) "context" .) }}
+      {{- with include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" (list .Values.admissionWebhooksPatchJob.image.pullSecrets) "context" .) }}
       imagePullSecrets:
         {{- . | nindent 8 }}
       {{- end }}
       containers:
         - name: create
           image: {{ include "newrelic.common.images.image" ( dict "defaultRegistry" "registry.k8s.io" "imageRoot" .Values.admissionWebhooksPatchJob.image "context" .) }}
-          imagePullPolicy: {{ .Values.admissionWebhooksPatchJob.image.pullPolicy }}
+          imagePullPolicy: {{ include "newrelic-infra-operator.admissionWebhooksPatchJob.imagePullPolicy" . }}
           args:
             - create
             - --host={{ include "newrelic.common.naming.fullname" . }},{{ include "newrelic.common.naming.fullname" . }}.{{ .Release.Namespace }}.svc

--- a/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -18,7 +18,8 @@ spec:
         app: {{ include "newrelic-infra-operator.name.admission-create" . }}
         {{- include "newrelic.common.labels.podLabels" . | nindent 8 }}
     spec:
-      {{- with include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" ( list .Values.admissionWebhooksPatchJob.image.pullSecrets ) "context" .) }}
+      {{- $globalPullSecrets := .Values.global.images.pullSecrets | default list }}
+      {{- with include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" ( concat $globalPullSecrets (list .Values.admissionWebhooksPatchJob.image.pullSecrets) ) "context" .) }}
       imagePullSecrets:
         {{- . | nindent 8 }}
       {{- end }}

--- a/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -18,15 +18,14 @@ spec:
         app: {{ include "newrelic-infra-operator.name.admission-patch" . }}
         {{- include "newrelic.common.labels" . | nindent 8 }}
     spec:
-      {{- $globalPullSecrets := .Values.global.images.pullSecrets | default list }}
-      {{- with include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" ( concat $globalPullSecrets (list .Values.admissionWebhooksPatchJob.image.pullSecrets) ) "context" .) }}
+      {{- with include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" (list .Values.admissionWebhooksPatchJob.image.pullSecrets) "context" .) }}
       imagePullSecrets:
         {{- . | nindent 8 }}
       {{- end }}
       containers:
         - name: patch
           image: {{ include "newrelic.common.images.image" ( dict "defaultRegistry" "registry.k8s.io" "imageRoot" .Values.admissionWebhooksPatchJob.image "context" .) }}
-          imagePullPolicy: {{ .Values.admissionWebhooksPatchJob.image.pullPolicy }}
+          imagePullPolicy: {{ include "newrelic-infra-operator.admissionWebhooksPatchJob.imagePullPolicy" . }}
           args:
             - patch
             - --webhook-name={{ include "newrelic.common.naming.fullname" . }}

--- a/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/newrelic-infra-operator/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -18,7 +18,8 @@ spec:
         app: {{ include "newrelic-infra-operator.name.admission-patch" . }}
         {{- include "newrelic.common.labels" . | nindent 8 }}
     spec:
-      {{- with include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" ( list .Values.admissionWebhooksPatchJob.image.pullSecrets ) "context" .) }}
+      {{- $globalPullSecrets := .Values.global.images.pullSecrets | default list }}
+      {{- with include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" ( concat $globalPullSecrets (list .Values.admissionWebhooksPatchJob.image.pullSecrets) ) "context" .) }}
       imagePullSecrets:
         {{- . | nindent 8 }}
       {{- end }}

--- a/charts/newrelic-infra-operator/templates/deployment.yaml
+++ b/charts/newrelic-infra-operator/templates/deployment.yaml
@@ -26,7 +26,8 @@ spec:
       securityContext:
         {{- . | nindent 8 }}
       {{- end }}
-      {{- with include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" ( list .Values.image.pullSecrets ) "context" .) }}
+      {{- $globalPullSecrets := .Values.global.images.pullSecrets | default list }}
+      {{- with include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" ( concat $globalPullSecrets (list .Values.image.pullSecrets) ) "context" .) }}
       imagePullSecrets:
         {{- . | nindent 8 }}
       {{- end }}

--- a/charts/newrelic-infra-operator/templates/deployment.yaml
+++ b/charts/newrelic-infra-operator/templates/deployment.yaml
@@ -26,15 +26,14 @@ spec:
       securityContext:
         {{- . | nindent 8 }}
       {{- end }}
-      {{- $globalPullSecrets := .Values.global.images.pullSecrets | default list }}
-      {{- with include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" ( concat $globalPullSecrets (list .Values.image.pullSecrets) ) "context" .) }}
+      {{- with include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" (list .Values.image.pullSecrets) "context" .) }}
       imagePullSecrets:
         {{- . | nindent 8 }}
       {{- end }}
       containers:
       - name: {{ include "newrelic.common.naming.name" . }}
         image: {{ include "newrelic.common.images.image" ( dict "imageRoot" .Values.image "context" .) }}
-        imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+        imagePullPolicy: {{ include "newrelic-infra-operator.imagePullPolicy" . }}
         {{- with include "newrelic.common.securityContext.container" . }}
         securityContext:
           {{- . | nindent 10 }}

--- a/charts/newrelic-infra-operator/tests/global-inheritance_test.yaml
+++ b/charts/newrelic-infra-operator/tests/global-inheritance_test.yaml
@@ -41,7 +41,7 @@ tests:
 
   # ========== IMAGE INHERITANCE TESTS ==========
   - it: uses default image when no registry override
-    set:
+    set: &base
       licenseKey: us-whatever
       cluster: test-cluster
     asserts:
@@ -52,8 +52,7 @@ tests:
 
   - it: uses global.images.registry for operator image
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
       global:
         images:
           registry: harbor.corp.net/newrelic
@@ -65,8 +64,7 @@ tests:
 
   - it: uses custom repository with global registry
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
       global:
         images:
           registry: harbor.corp.net/newrelic
@@ -80,8 +78,7 @@ tests:
 
   - it: local image registry overrides global registry
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
       global:
         images:
           registry: harbor.corp.net/newrelic
@@ -97,8 +94,7 @@ tests:
   # ========== IMAGE PULL SECRETS INHERITANCE TESTS ==========
   - it: sets imagePullSecrets from global
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
       global:
         images:
           pullSecrets:
@@ -111,8 +107,7 @@ tests:
 
   - it: merges global and local imagePullSecrets (global then local)
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
       global:
         images:
           pullSecrets:
@@ -132,8 +127,7 @@ tests:
 
   - it: has no imagePullSecrets by default when neither global nor local set
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
     asserts:
       - isNull:
           path: spec.template.spec.imagePullSecrets
@@ -142,8 +136,7 @@ tests:
   # ========== NODE SELECTOR INHERITANCE TESTS ==========
   - it: includes linux os selector by default
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
     asserts:
       - equal:
           path: spec.template.spec.nodeSelector["kubernetes.io/os"]
@@ -152,8 +145,7 @@ tests:
 
   - it: adds global nodeSelector to linux selector
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
       global:
         nodeSelector:
           monitoring: "true"
@@ -169,8 +161,7 @@ tests:
 
   - it: local nodeSelector overrides global
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
       global:
         nodeSelector:
           environment: global-value
@@ -189,8 +180,7 @@ tests:
   # ========== TOLERATIONS INHERITANCE TESTS ==========
   - it: sets tolerations from global
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
       global:
         tolerations:
           - key: monitoring
@@ -209,8 +199,7 @@ tests:
 
   - it: local tolerations override global
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
       global:
         tolerations:
           - key: monitoring
@@ -234,8 +223,7 @@ tests:
 
   - it: has no tolerations by default when neither global nor local set
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
     asserts:
       - isNull:
           path: spec.template.spec.tolerations
@@ -244,8 +232,7 @@ tests:
   # ========== AFFINITY INHERITANCE TESTS ==========
   - it: sets affinity from global
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
       global:
         affinity:
           nodeAffinity:
@@ -264,8 +251,7 @@ tests:
 
   - it: local affinity overrides global
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
       global:
         affinity:
           nodeAffinity:
@@ -297,8 +283,7 @@ tests:
 
   - it: has no affinity by default when neither global nor local set
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
     asserts:
       - isNull:
           path: spec.template.spec.affinity
@@ -307,8 +292,7 @@ tests:
   # ========== PRIORITY CLASS INHERITANCE TESTS ==========
   - it: sets priorityClassName from global
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
       global:
         priorityClassName: high-priority
     asserts:
@@ -319,8 +303,7 @@ tests:
 
   - it: local priorityClassName overrides global
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
       global:
         priorityClassName: global-priority
       priorityClassName: local-priority
@@ -332,8 +315,7 @@ tests:
 
   - it: has no priorityClassName by default when neither global nor local set
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
     asserts:
       - isNull:
           path: spec.template.spec.priorityClassName
@@ -342,8 +324,7 @@ tests:
   # ========== DNS CONFIG INHERITANCE TESTS ==========
   - it: sets dnsConfig from global
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
       global:
         dnsConfig:
           options:
@@ -357,8 +338,7 @@ tests:
 
   - it: local dnsConfig overrides global
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
       global:
         dnsConfig:
           options:
@@ -376,8 +356,7 @@ tests:
 
   - it: has no dnsConfig by default when neither global nor local set
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
     asserts:
       - isNull:
           path: spec.template.spec.dnsConfig
@@ -386,8 +365,7 @@ tests:
   # ========== HOST NETWORK INHERITANCE TESTS ==========
   - it: default hostNetwork is false
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
     asserts:
       - equal:
           path: spec.template.spec.hostNetwork
@@ -396,8 +374,7 @@ tests:
 
   - it: sets hostNetwork from local when true
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
       hostNetwork: true
     asserts:
       - equal:
@@ -411,8 +388,7 @@ tests:
 
   - it: sets hostNetwork from global when local not set
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
       global:
         hostNetwork: true
     asserts:
@@ -427,8 +403,7 @@ tests:
 
   - it: local hostNetwork overrides global
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
       global:
         hostNetwork: true
       hostNetwork: false
@@ -441,8 +416,7 @@ tests:
   # ========== SERVICE ACCOUNT INHERITANCE TESTS ==========
   - it: uses service account name from global
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
       global:
         serviceAccount:
           name: custom-sa
@@ -454,8 +428,7 @@ tests:
 
   - it: local service account name overrides global
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
       global:
         serviceAccount:
           name: global-sa
@@ -469,8 +442,7 @@ tests:
 
   - it: has default service account name when neither global nor local set
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
     asserts:
       - matchRegex:
           path: spec.template.spec.serviceAccountName
@@ -480,8 +452,7 @@ tests:
   # ========== POD SECURITY CONTEXT INHERITANCE TESTS ==========
   - it: uses default pod security context from values.yaml
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
     asserts:
       - equal:
           path: spec.template.spec.securityContext.fsGroup
@@ -490,8 +461,7 @@ tests:
 
   - it: global pod security context used when local set to null
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
       podSecurityContext: null
       global:
         podSecurityContext:
@@ -504,8 +474,7 @@ tests:
 
   - it: local pod security context overrides global
     set:
-      licenseKey: us-whatever
-      cluster: test-cluster
+      <<: *base
       global:
         podSecurityContext:
           fsGroup: 2000

--- a/charts/newrelic-infra-operator/values.yaml
+++ b/charts/newrelic-infra-operator/values.yaml
@@ -26,6 +26,7 @@ image:
 # @default -- See `values.yaml`
 admissionWebhooksPatchJob:
   image:
+    # -- Defaults to registry.k8s.io. If global.images.registry is set, it will be used instead.
     registry:  # Defaults to registry.k8s.io
     repository: ingress-nginx/kube-webhook-certgen
     tag: v1.3.0
@@ -146,6 +147,7 @@ config:
       # -- Image of the infrastructure agent to be injected.
       # @default -- See `values.yaml`
       image:
+        # -- Defaults to newrelic/infrastructure-k8s. If global.images.registry is set, it will be used instead.
         repository: newrelic/infrastructure-k8s
         tag: 2.13.15-unprivileged
         pullPolicy: IfNotPresent

--- a/charts/newrelic-infra-operator/values.yaml
+++ b/charts/newrelic-infra-operator/values.yaml
@@ -15,6 +15,7 @@ customSecretLicenseKey: ""
 # -- Image for the New Relic Infrastructure Operator
 # @default -- See `values.yaml`
 image:
+  # -- Registry override for the operator image. Takes precedence over global.images.registry.
   registry:
   repository: newrelic/newrelic-infra-operator
   tag: ""
@@ -27,7 +28,8 @@ image:
 # @default -- See `values.yaml`
 admissionWebhooksPatchJob:
   image:
-    registry:  # Defaults to registry.k8s.io
+    # -- Registry override for the admission webhook patch job image. Takes precedence over global.images.registry. Defaults to registry.k8s.io when not set.
+    registry:
     repository: ingress-nginx/kube-webhook-certgen
     tag: v1.3.0
     pullPolicy:

--- a/charts/newrelic-infra-operator/values.yaml
+++ b/charts/newrelic-infra-operator/values.yaml
@@ -15,9 +15,10 @@ customSecretLicenseKey: ""
 # -- Image for the New Relic Infrastructure Operator
 # @default -- See `values.yaml`
 image:
+  registry:
   repository: newrelic/newrelic-infra-operator
   tag: ""
-  pullPolicy: IfNotPresent
+  pullPolicy:
   # -- The secrets that are needed to pull images from a custom registry.
   pullSecrets: []
   # - name: regsecret
@@ -26,11 +27,10 @@ image:
 # @default -- See `values.yaml`
 admissionWebhooksPatchJob:
   image:
-    # -- Defaults to registry.k8s.io. If global.images.registry is set, it will be used instead.
     registry:  # Defaults to registry.k8s.io
     repository: ingress-nginx/kube-webhook-certgen
     tag: v1.3.0
-    pullPolicy: IfNotPresent
+    pullPolicy:
     # -- The secrets that are needed to pull images from a custom registry.
     pullSecrets: []
     # - name: regsecret
@@ -147,10 +147,11 @@ config:
       # -- Image of the infrastructure agent to be injected.
       # @default -- See `values.yaml`
       image:
-        # -- Defaults to newrelic/infrastructure-k8s. If global.images.registry is set, it will be used instead.
+        # -- Registry override for the sidecar image. Takes precedence over global.images.registry.
+        registry:
         repository: newrelic/infrastructure-k8s
         tag: 2.13.15-unprivileged
-        pullPolicy: IfNotPresent
+        pullPolicy:
 
       # -- configSelectors is the way to configure resource requirements and extra envVars of the injected sidecar container.
       # When mutating it will be applied the first configuration having the labelSelector matching with the mutating pod.


### PR DESCRIPTION
## Summary

Add support for cascading registry, pullSecrets, and pullPolicy from global settings to newrelic-infra-operator, following the standard NR chart precedence model: **chart-specific → global → chart default**.

### Phase 1: Global.Images.Registry Support ✅
- Added `registry:` field to all image configs (`image:`, `admissionWebhooksPatchJob.image:`, `config.infraAgentInjection.agentConfig.image:`) to allow chart-specific overrides
- Added `newrelic-infra-operator.sidecar.image` helper to resolve sidecar registry with correct precedence
- Updated configmap to use the new image helper for sidecar injection

### Phase 2: Global.Images.PullSecrets Support ✅
- Added global.images.pullSecrets support to deployment and other manifests
- Global and chart-level pullSecrets are concatenated together

### Phase 3: Global.Images.PullPolicy Support ✅
- Added pullPolicy helpers to `_helpers.tpl`:
  - `newrelic-infra-operator.imagePullPolicy` for operator image
  - `newrelic-infra-operator.admissionWebhooksPatchJob.imagePullPolicy` for webhook patch job image
  - `newrelic-infra-operator.sidecar.imagePullPolicy` for injected sidecar image
- Updated relevant manifests to use pullPolicy helpers
- Nulled out `pullPolicy: IfNotPresent` defaults in values.yaml so global can take effect when no chart-level policy is explicitly set

## Configuration Hierarchy

**For Image Registry:**
1. Chart-level `image.registry` / `admissionWebhooksPatchJob.image.registry` / `config.infraAgentInjection.agentConfig.image.registry`
2. `global.images.registry`
3. Chart default (e.g. `registry.k8s.io` for the webhook job image)

**For ImagePullSecrets:**
1. `global.images.pullSecrets` and chart-level `image.pullSecrets` are **concatenated** (both applied)

**For ImagePullPolicy:**
1. Chart-level `image.pullPolicy` / `admissionWebhooksPatchJob.image.pullPolicy` / `config.infraAgentInjection.agentConfig.image.pullPolicy`
2. `global.images.pullPolicy`
3. Default: `IfNotPresent`

## Backward Compatibility

✅ **Fully backward compatible:**
- Existing values.yaml configurations continue to work unchanged
- Chart-level registry/pullPolicy settings always override global

## Test Plan

**Registry:**
- ✓ Global registry is used when no chart-level registry is set: `my.registry.io/newrelic/infrastructure-k8s:...`
- ✓ Defaults to standard image when neither chart nor global registry is configured
- ✓ Chart-level registry overrides global: `chart.registry.io/newrelic/infrastructure-k8s:...`

**PullSecrets:**
- ✓ No pullSecrets set → No imagePullSecrets section rendered
- ✓ Global pullSecrets only → Uses global
- ✓ Both global + chart pullSecrets → Uses both (concatenated)

**PullPolicy:**
- ✓ No overrides → defaults to `IfNotPresent`
- ✓ Global pullPolicy set → all images adopt it
- ✓ Chart-level pullPolicy overrides global

## Impact

Users can now configure image pull behavior globally:

```yaml
global:
  images:
    registry: "my.private.registry.com"
    pullSecrets:
      - name: my-registry-credentials
    pullPolicy: Always
```

Chart-level overrides still take precedence:

```yaml
image:
  registry: "override.registry.com"   # wins over global
  pullPolicy: Never                   # wins over global
```

This is part of a broader effort to ensure all New Relic Helm charts in the nri-bundle support consistent private registry configuration.
