### PR TITLE
feat(breaking): Change image to nri-kubernetes v3 sidecar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### breaking
+- v3 Fargate support. You may need to update your image repo and tag to point to the new sidecar images. @danielstokes [#707](https://github.com/newrelic/newrelic-infra-operator/pull/707)
+
 ## v0.27.5 - 2026-06-29
 
 ### dependency

--- a/charts/newrelic-infra-operator/Chart.yaml
+++ b/charts/newrelic-infra-operator/Chart.yaml
@@ -13,18 +13,18 @@ dependencies:
     version: 2.3.3
     repository: "https://helm-charts.newrelic.com"
 maintainers:
-  - name: alvarocabanas
-    url: https://github.com/alvarocabanas
-  - name: carlossscastro
-    url: https://github.com/carlossscastro
-  - name: sigilioso
-    url: https://github.com/sigilioso
-  - name: gsanchezgavier
-    url: https://github.com/gsanchezgavier
-  - name: marcsanmi
-    url: https://github.com/marcsanmi
-  - name: paologallinaharbur
-    url: https://github.com/paologallinaharbur
+  - name: danielstokes
+    url: https://github.com/danielstokes
+  - name: dbudziwojskiNR
+    url: https://github.com/dbudziwojskiNR
+  - name: jamescripter
+    url: https://github.com/jamescripter
+  - name: NRhzhao
+    url: https://github.com/NRhzhao
+  - name: Philip-R-Beckwith
+    url: https://github.com/Philip-R-Beckwith
+  - name: TmNguyen12
+    url: https://github.com/TmNguyen12
 keywords:
   - infrastructure
   - newrelic

--- a/charts/newrelic-infra-operator/README.md
+++ b/charts/newrelic-infra-operator/README.md
@@ -107,9 +107,9 @@ Options that can be defined globally include `affinity`, `nodeSelector`, `tolera
 
 ## Maintainers
 
-* [alvarocabanas](https://github.com/alvarocabanas)
-* [carlossscastro](https://github.com/carlossscastro)
-* [sigilioso](https://github.com/sigilioso)
-* [gsanchezgavier](https://github.com/gsanchezgavier)
-* [marcsanmi](https://github.com/marcsanmi)
-* [paologallinaharbur](https://github.com/paologallinaharbur)
+* [danielstokes](https://github.com/danielstokes)
+* [dbudziwojskiNR](https://github.com/dbudziwojskiNR)
+* [jamescripter](https://github.com/jamescripter)
+* [NRhzhao](https://github.com/NRhzhao)
+* [Philip-R-Beckwith](https://github.com/Philip-R-Beckwith)
+* [TmNguyen12](https://github.com/TmNguyen12)

--- a/charts/newrelic-infra-operator/values.yaml
+++ b/charts/newrelic-infra-operator/values.yaml
@@ -151,8 +151,8 @@ config:
       image:
         # -- Registry override for the sidecar image. Takes precedence over global.images.registry.
         registry:
-        repository: newrelic/infrastructure-k8s
-        tag: 2.13.15-unprivileged
+        repository: newrelic/nri-kubernetes
+        tag: 4.3.5-sidecar
         pullPolicy:
 
       # -- configSelectors is the way to configure resource requirements and extra envVars of the injected sidecar container.

--- a/charts/newrelic-infra-operator/values.yaml
+++ b/charts/newrelic-infra-operator/values.yaml
@@ -152,7 +152,7 @@ config:
         # -- Registry override for the sidecar image. Takes precedence over global.images.registry.
         registry:
         repository: newrelic/nri-kubernetes
-        tag: 4.3.5-sidecar
+        tag: 4.3.6-sidecar
         pullPolicy:
 
       # -- configSelectors is the way to configure resource requirements and extra envVars of the injected sidecar container.


### PR DESCRIPTION
## Description
Adds nri-kubernetes v3 support. This is a breaking change and you may need to update your image repo and tag to correctly point at the new sidecar images. Please review the default `values.yaml` file for details on the new image.

## Type of change
<!-- Please check the relevant option. -->

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](https://github.com/newrelic/newrelic-infra-operator/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  